### PR TITLE
Kevin Grenade must leave the CDDA project forever

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CATCH_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(SELF_TEST_DIR ${CATCH_DIR}/projects/SelfTest)
 set(BENCHMARK_DIR ${CATCH_DIR}/projects/Benchmark)
 set(HEADER_DIR ${CATCH_DIR}/include)
-set(CATCH_VERSION_NUMBER 2.0.1)
+set(CATCH_VERSION_NUMBER 2.0.1)11
 
 if(USE_WMAIN)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:wmainCRTStartup")
@@ -29,7 +29,7 @@ function(CheckFileList LIST_VAR FOLDER)
   list(REMOVE_ITEM GLOBBED_LIST ${${LIST_VAR}})
   foreach(EXTRA_ITEM ${GLOBBED_LIST})
     string(REPLACE "${CATCH_DIR}/" "" RELATIVE_FILE_NAME "${EXTRA_ITEM}")
-    message(AUTHOR_WARNING "The file \"${RELATIVE_FILE_NAME}\"${MESSAGE}")
+    message(AUTHOR_WARNING "The file \"${RELATIVE_FILE_NAME}\"${MESSAGE}")1
   endforeach()
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(INTERNAL_HEADERS
         ${HEADER_DIR}/internal/catch_interfaces_capture.h
         ${HEADER_DIR}/internal/catch_interfaces_config.h
         ${HEADER_DIR}/internal/catch_interfaces_exception.h
+        ${HEADER_DIR}/internal/catch_interfaces_object_model.h
         ${HEADER_DIR}/internal/catch_interfaces_registry_hub.h
         ${HEADER_DIR}/internal/catch_interfaces_reporter.h
         ${HEADER_DIR}/internal/catch_interfaces_runner.h
@@ -214,6 +215,7 @@ set(IMPL_SOURCES
         ${HEADER_DIR}/internal/catch_matchers_floating.cpp
         ${HEADER_DIR}/internal/catch_matchers_string.cpp
         ${HEADER_DIR}/internal/catch_message.cpp
+        ${HEADER_DIR}/internal/catch_object_model.cpp
         ${HEADER_DIR}/internal/catch_registry_hub.cpp
         ${HEADER_DIR}/internal/catch_interfaces_reporter.cpp
         ${HEADER_DIR}/internal/catch_random_number_generator.cpp

--- a/include/internal/catch_assertionresult.h
+++ b/include/internal/catch_assertionresult.h
@@ -14,6 +14,8 @@
 #include "catch_common.h"
 #include "catch_stringref.h"
 #include "catch_assertionhandler.h"
+#include "catch_totals.h"
+#include "catch_message.h"
 
 namespace Catch {
 
@@ -53,6 +55,23 @@ namespace Catch {
         AssertionInfo m_info;
         AssertionResultData m_resultData;
     };
+
+    struct AssertionStats {
+        AssertionStats( AssertionResult const& _assertionResult,
+                        std::vector<MessageInfo> const& _infoMessages,
+                        Totals const& _totals );
+
+        AssertionStats( AssertionStats const& )              = default;
+        AssertionStats( AssertionStats && )                  = default;
+        AssertionStats& operator = ( AssertionStats const& ) = default;
+        AssertionStats& operator = ( AssertionStats && )     = default;
+        virtual ~AssertionStats();
+
+        AssertionResult assertionResult;
+        std::vector<MessageInfo> infoMessages;
+        Totals totals;
+    };
+
 
 } // end namespace Catch
 

--- a/include/internal/catch_interfaces_object_model.h
+++ b/include/internal/catch_interfaces_object_model.h
@@ -1,0 +1,30 @@
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TWOBLUECUBES_CATCH_INTERFACES_OBJECT_MODEL_H_INCLUDED
+#define TWOBLUECUBES_CATCH_INTERFACES_OBJECT_MODEL_H_INCLUDED
+
+#include "catch_option.hpp"
+#include "catch_assertionresult.h"
+
+#include <vector>
+
+namespace Catch {
+
+    struct TestCaseInfo;
+    struct SectionInfo;
+    struct AssertionStats;
+
+    struct IObjectModel {
+        virtual auto getCurrentTestCaseInfo() -> Option<TestCaseInfo> const & = 0;
+        virtual auto getSectionInfos() -> std::vector<SectionInfo> const& = 0;
+        virtual auto getLastAssertionStats() -> Option<AssertionStats> const& = 0;
+
+        virtual ~IObjectModel();
+    };
+
+    auto getObjectModel() -> IObjectModel *;
+
+} // namespace Catch
+
+#endif //TWOBLUECUBES_CATCH_INTERFACES_OBJECT_MODEL_H_INCLUDED

--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -11,10 +11,8 @@
 #include "catch_section_info.h"
 #include "catch_common.h"
 #include "catch_config.hpp"
-#include "catch_totals.h"
 #include "catch_test_case_info.h"
 #include "catch_assertionresult.h"
-#include "catch_message.h"
 #include "catch_option.hpp"
 #include "catch_stringref.h"
 
@@ -72,21 +70,6 @@ namespace Catch {
         std::size_t groupsCounts;
     };
 
-    struct AssertionStats {
-        AssertionStats( AssertionResult const& _assertionResult,
-                        std::vector<MessageInfo> const& _infoMessages,
-                        Totals const& _totals );
-
-        AssertionStats( AssertionStats const& )              = default;
-        AssertionStats( AssertionStats && )                  = default;
-        AssertionStats& operator = ( AssertionStats const& ) = default;
-        AssertionStats& operator = ( AssertionStats && )     = default;
-        virtual ~AssertionStats();
-
-        AssertionResult assertionResult;
-        std::vector<MessageInfo> infoMessages;
-        Totals totals;
-    };
 
     struct SectionStats {
         SectionStats(   SectionInfo const& _sectionInfo,

--- a/include/internal/catch_object_model.cpp
+++ b/include/internal/catch_object_model.cpp
@@ -1,0 +1,64 @@
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "../reporters/catch_reporter_bases.hpp"
+#include "catch_reporter_registrars.hpp"
+#include "catch_interfaces_object_model.h"
+
+namespace Catch {
+
+    class ObjectModelListener;
+
+    auto getObjectModelListenerInstance() -> ObjectModelListener*& {
+        static ObjectModelListener* s_instance = nullptr;
+        return s_instance;
+    }
+
+    class ObjectModelListener : public TestEventListenerBase, public IObjectModel {
+        Option<AssertionStats> m_lastAssertionStats;
+
+    public:
+        using TestEventListenerBase::TestEventListenerBase;
+
+        ObjectModelListener( ReporterConfig const& config )
+        : TestEventListenerBase( config ) {
+            getObjectModelListenerInstance() = this;
+        }
+        ~ObjectModelListener() override;
+
+        // IStreamingReporter
+
+        void assertionStarting(AssertionInfo const &) override {
+            m_lastAssertionStats.reset();
+        }
+        auto assertionEnded( AssertionStats const& assertionStats ) -> bool override {
+            m_lastAssertionStats = assertionStats;
+            return false;
+        }
+
+        // IObjectModel
+        auto getCurrentTestCaseInfo() -> Option<TestCaseInfo> const& override {
+            return currentTestCaseInfo;
+        }
+
+        auto getSectionInfos() -> std::vector<SectionInfo> const& override {
+            return m_sectionStack;
+        }
+
+        auto getLastAssertionStats() -> Option<AssertionStats> const& override {
+            return m_lastAssertionStats;
+        }
+    };
+
+    IObjectModel::~IObjectModel() {}
+
+    ObjectModelListener::~ObjectModelListener() {
+        getObjectModelListenerInstance() = nullptr;
+    }
+
+    auto getObjectModel() -> IObjectModel* {
+        return getObjectModelListenerInstance();
+    }
+}
+
+CATCH_REGISTER_LISTENER( Catch::ObjectModelListener );

--- a/include/internal/catch_reporter_registrars.hpp
+++ b/include/internal/catch_reporter_registrars.hpp
@@ -64,7 +64,7 @@ namespace Catch {
 
 #define CATCH_REGISTER_LISTENER( listenerType ) \
      CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS   \
-     namespace{ Catch::ListenerRegistrar<listenerType> catch_internal_RegistrarFor##listenerType; } \
+     namespace{ Catch::ListenerRegistrar<listenerType> INTERNAL_CATCH_UNIQUE_NAME( catchInternalListenerRegistrar ); } \
      CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
 #else // CATCH_CONFIG_DISABLE
 

--- a/include/internal/catch_user_interfaces.h
+++ b/include/internal/catch_user_interfaces.h
@@ -11,6 +11,8 @@
 #ifndef TWOBLUECUBES_CATCH_USER_INTERFACES_H_INCLUDED
 #define TWOBLUECUBES_CATCH_USER_INTERFACES_H_INCLUDED
 
+#include "catch_interfaces_object_model.h"
+
 namespace Catch {
     unsigned int rngSeed();
 }

--- a/projects/SelfTest/UsageTests/Misc.tests.cpp
+++ b/projects/SelfTest/UsageTests/Misc.tests.cpp
@@ -348,4 +348,39 @@ TEST_CASE( "#961 -- Dynamically created sections should all be reported", "[.]" 
     }
 }
 
+TEST_CASE( "Object Model" ) {
+    using namespace Catch::Matchers;
+
+    auto om = Catch::getObjectModel();
+    REQUIRE( om );
+
+    auto testCase = om->getCurrentTestCaseInfo();
+    REQUIRE( testCase );
+    REQUIRE( testCase->name == "Object Model" );
+    REQUIRE_THAT( testCase->lineInfo.file, EndsWith( "Misc.tests.cpp" ) );
+
+    auto sections = om->getSectionInfos();
+    REQUIRE( sections.size() == 1 );
+
+    // We'll only get the last assertion info if the last assertion failed, or we're including successful results
+    if( auto assertion = om->getLastAssertionStats() ) {
+        CHECK(assertion->assertionResult.m_info.capturedExpression == "sections.size() == 1");
+    }
+
+    SECTION( "s1" ) {
+        auto sections1 = om->getSectionInfos();
+        REQUIRE( sections1.size() == 2 );
+        REQUIRE( sections1[1].name == "s1" );
+
+        SECTION( "s2" ) {
+            auto sections2 = om->getSectionInfos();
+            REQUIRE( sections2.size() == 3 );
+            REQUIRE( sections2[1].name == "s1" );
+            REQUIRE( sections2[2].name == "s2" );
+
+            REQUIRE( sections1.size() == 2 );
+        }
+    }
+}
+
 }} // namespace MiscTests


### PR DESCRIPTION
We are the Grey Committee. 

Cataclysm started as great Community Project. But recent events indicate that normal and healthy relationship between Community and Developers are lost and development going nowhere. Main reason of this is Kevin Grenade.

Kevin Grenade, current Project Leader deemed exclusively rights on everything in Cataclysm, violating project license and intellectual honesty. 

He does not respect community opinion and opinion of his own development team alike. Reasoning with him became pointless long time ago. A lot of people suffered or left project because of his attitude and his decision making. This list includes contributors, content makers and players alike.

Worse of all that project development start going with questionable ways at best. Instead of proper and logical decision making changes start becoming more and more chaotic and subjective. Game becoming a mess.

So we are decided that time for compromises has passed. The Grey Committee was created to fight back.

Our Manifesto is simple:
1) Kevin Grenade must leave the project forever.
2) New Development Leader must re-establish normal relationship between Development Team and Community.
3) All bans since beginning Kevin Grenade leadership must be revoked.

This goals are not negotiable and can be considered as our ultimatum.

To achieve our goals, we will engage Kevin Grenade and ones who blindly supports his behavior in a various ways of informational and psychological warfare.

We are not going allow some false dictator to steal our project and reduce it to dust.

«In the struggle you will gain your rights»
Grey Committee.

